### PR TITLE
[INFRA] Update test infrastructure.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,5 +45,5 @@ add_subdirectory (doc EXCLUDE_FROM_ALL)
 
 ## TEST
 
-enable_testing ()
-add_subdirectory (test EXCLUDE_FROM_ALL)
+add_subdirectory (test/api EXCLUDE_FROM_ALL)
+add_subdirectory (test/cli EXCLUDE_FROM_ALL)

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -1,6 +1,19 @@
 cmake_minimum_required (VERSION 3.8)
 
+include (../jstmap_test.cmake)
+
+# TODO: infra improvements
+# include (diagnostics/list_unused_unit_tests) TODO: Enable me!
+
+# jstmap_require_ccache ()
+# jstmap_require_test ()
+
+#list_unused_unit_tests ()
+
+### add subdirectories:
+
 add_subdirectory (jstmap)
 add_subdirectory (libjst)
+
 # add_api_test (convert_fastq_test.cpp)
 # target_use_datasources (convert_fastq_test FILES in.fastq)

--- a/test/api/jstmap/index/CMakeLists.txt
+++ b/test/api/jstmap/index/CMakeLists.txt
@@ -1,2 +1,7 @@
+cmake_minimum_required (VERSION 3.8)
 
-add_api_test (load_sequence_test.cpp)
+macro (add_jstmap_index_test test_filename)
+    add_api_test(${test_filename} "jstmap::index")
+endmacro ()
+
+add_jstmap_index_test (load_sequence_test.cpp)

--- a/test/api/libjst/CMakeLists.txt
+++ b/test/api/libjst/CMakeLists.txt
@@ -1,1 +1,7 @@
-add_api_test (journaled_sequence_tree_test.cpp)
+cmake_minimum_required (VERSION 3.8)
+
+macro (add_libjst_test test_filename)
+    add_api_test(${test_filename} "libjst::libjst")
+endmacro()
+
+add_libjst_test (journaled_sequence_tree_test.cpp)


### PR DESCRIPTION
* Changes global test cmake lists file to a cmake script file
* updates add test macro to specify additional list of dependent libraries
* Improves build times by less dependencies, i.e. only the needed libraries are linked against the test target.