### PR TITLE
[FEATURE] Add simple debug logging.

### DIFF
--- a/libjst/libjst/utility/logger.hpp
+++ b/libjst/libjst/utility/logger.hpp
@@ -6,7 +6,7 @@
 // -----------------------------------------------------------------------------------------------------
 
 /*!\file
- * \brief Provides libjst::utility::logger.
+ * \brief Provides logging utilities for printing more debug information during the JST construction and traversal.
  * \author Rene Rahn <rene.rahn AT fu-berlin.de>
  */
 


### PR DESCRIPTION
Fixes #37 
A simple logging mechanism to enable/disable debug messages for the JST.
The logging message includes the file and the line number to easily navigate to the respective position inside of the IDE.