### PR TITLE
Libjst/bit vector

### DIFF
--- a/libjst/libjst/utility/bit_vector.hpp
+++ b/libjst/libjst/utility/bit_vector.hpp
@@ -189,6 +189,12 @@ public:
     {
         return _size;
     }
+
+    //!\brief Checks wether the container is empty.
+    constexpr bool empty() const noexcept
+    {
+        return _size == 0;
+    }
     //!\}
 
     /*!\name Modifiers

--- a/test/api/libjst/utility/bit_vector_test.cpp
+++ b/test/api/libjst/utility/bit_vector_test.cpp
@@ -630,6 +630,24 @@ TEST(bit_vector_test, size)
     }
 }
 
+TEST(bit_vector_test, empty)
+{
+    {
+        libjst::bit_vector test_vector{};
+        EXPECT_TRUE(test_vector.empty());
+    }
+
+    {
+        libjst::bit_vector test_vector(1);
+        EXPECT_FALSE(test_vector.empty());
+    }
+
+    {
+        libjst::bit_vector test_vector(1000);
+        EXPECT_FALSE(test_vector.empty());
+    }
+}
+
 // ----------------------------------------------------------------------------
 // Iterator test
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Adds the non-member versions of the binary operators of the bit set.