### PR TITLE
[FEATURE] Add initial view sub-command to jstmap.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ add_subdirectory (libjst)
 add_subdirectory (jstmap-index)
 add_subdirectory (jstmap-search)
 add_subdirectory (jstmap-simulate)
+add_subdirectory (jstmap-view)
 add_subdirectory (jstmap)
 
 ## DOCUMENTATION

--- a/jstmap-view/CMakeLists.txt
+++ b/jstmap-view/CMakeLists.txt
@@ -1,0 +1,29 @@
+
+file(GLOB HEADER_LIST CONFIGURE_DEPENDS "jstmap/view/*.hpp")
+
+### Base interface target for the index subcommand.
+add_library (jstmap_view_base INTERFACE)
+target_include_directories (jstmap_view_base INTERFACE ../jstmap-view seqan3::seqan3)
+target_link_libraries (jstmap_view_base INTERFACE seqan3::seqan3 libjst::libjst)
+add_library (jstmap::view::base ALIAS jstmap_view_base)
+
+### Create object library for better build times
+add_library(jstmap_view_load_jst OBJECT jstmap/view/load_jst.cpp
+                                        jstmap/view/load_jst.hpp
+                                        jstmap/view/global_types.hpp)
+target_include_directories (jstmap_view_load_jst PUBLIC jstmap::view::base)
+target_link_libraries (jstmap_view_load_jst PUBLIC jstmap::view::base)
+
+add_library(jstmap_view_format_fasta OBJECT jstmap/view/view_format_fasta.cpp
+                                            jstmap/view/view_format_fasta.hpp
+                                            jstmap/view/global_types.hpp)
+target_include_directories (jstmap_view_format_fasta PUBLIC jstmap::view::base)
+target_link_libraries (jstmap_view_format_fasta PUBLIC jstmap::view::base)
+
+### Create static library for index subcommand
+add_library (jstmap_view STATIC jstmap/view/view_main.cpp)
+target_include_directories (jstmap_view PUBLIC jstmap_view_format_fasta jstmap_view_load_jst)
+target_link_libraries (jstmap_view PUBLIC jstmap_view_format_fasta jstmap_view_load_jst)
+add_library (jstmap::view ALIAS jstmap_view)
+
+unset (HEADER_LIST)

--- a/jstmap-view/jstmap/view/global_types.hpp
+++ b/jstmap-view/jstmap/view/global_types.hpp
@@ -1,0 +1,29 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides globally defined types for the view subprogram.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <vector>
+
+#include <seqan3/alphabet/nucleotide/dna5.hpp>
+
+#include <libjst/journaled_sequence_tree.hpp>
+
+namespace jstmap
+{
+
+//!\brief The sequence type loaded from the disk.
+using raw_sequence_t = std::vector<seqan3::dna5>;
+//!\brief The globally available journal sequence tree type.
+using jst_t = libjst::journaled_sequence_tree<raw_sequence_t>;
+
+}  // namespace jstmap

--- a/jstmap-view/jstmap/view/load_jst.cpp
+++ b/jstmap-view/jstmap/view/load_jst.cpp
@@ -1,0 +1,39 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/rrahn/just_map/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <fstream>
+#include <string>
+
+#include <cereal/archives/binary.hpp>
+
+#include <jstmap/view/load_jst.hpp>
+
+namespace jstmap
+{
+
+jst_t load_jst(std::filesystem::path const & jst_input_file_path)
+{
+    using namespace std::literals;
+
+    std::fstream jst_input_stream{jst_input_file_path};
+
+    if (!jst_input_stream.good())
+        throw std::runtime_error{"Couldn't open path for loading the jst! The path is ["s +
+                                 jst_input_file_path.string() +
+                                 "]"s};
+
+    jst_t jst{};
+
+    {
+        cereal::BinaryInputArchive input_archive{jst_input_stream};
+        jst.load(input_archive);
+    }
+
+    return jst;
+}
+
+} // namespace jstmap

--- a/jstmap-view/jstmap/view/load_jst.hpp
+++ b/jstmap-view/jstmap/view/load_jst.hpp
@@ -1,0 +1,17 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/rrahn/just_map/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <filesystem>
+
+#include <jstmap/view/global_types.hpp>
+
+namespace jstmap
+{
+
+jst_t load_jst(std::filesystem::path const &);
+
+} // namespace jstmap

--- a/jstmap-view/jstmap/view/options.hpp
+++ b/jstmap-view/jstmap/view/options.hpp
@@ -1,0 +1,26 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides the options for the view sub-command.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <filesystem>
+
+namespace jstmap
+{
+
+struct view_options
+{
+    std::filesystem::path jst_file{}; //!< The file path contianing the jst to extract sequence information for.
+    size_t haplotype_index{0}; //!< The haploype index to view.
+};
+
+}  // namespace jstmap

--- a/jstmap-view/jstmap/view/view_format_fasta.cpp
+++ b/jstmap-view/jstmap/view/view_format_fasta.cpp
@@ -1,0 +1,27 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/rrahn/just_map/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <fstream>
+#include <string>
+
+#include <seqan3/io/sequence_file/output.hpp>
+
+#include <jstmap/view/view_format_fasta.hpp>
+
+namespace jstmap
+{
+
+void view_as_format(jst_t const & jst, size_t const haplotype_index)
+{
+    using namespace std::literals;
+
+    seqan3::sequence_file_output view_out{std::cout, seqan3::format_fasta{}};
+    view_out.emplace_back(jst.sequence_at(haplotype_index),
+                          "ID_"s + std::to_string(haplotype_index));
+}
+
+} // namespace jstmap

--- a/jstmap-view/jstmap/view/view_format_fasta.hpp
+++ b/jstmap-view/jstmap/view/view_format_fasta.hpp
@@ -1,0 +1,22 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/rrahn/just_map/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides the functionality to view a particular haplotype of the jst.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#include <jstmap/view/global_types.hpp>
+#include <jstmap/view/options.hpp>
+
+namespace jstmap
+{
+
+//!\brief Displays haplotype for the specified index in fasta format.
+void view_as_format(jst_t const & jst, size_t const index);
+
+} // namespace jstmap

--- a/jstmap-view/jstmap/view/view_main.cpp
+++ b/jstmap-view/jstmap/view/view_main.cpp
@@ -1,0 +1,67 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/rrahn/just_map/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides the main entry point of the just_map viewer.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#include <seqan3/argument_parser/argument_parser.hpp>
+#include <seqan3/argument_parser/exceptions.hpp>
+#include <seqan3/argument_parser/validators.hpp>
+
+#include <jstmap/view/load_jst.hpp>
+#include <jstmap/view/options.hpp>
+#include <jstmap/view/view_format_fasta.hpp>
+
+namespace jstmap
+{
+
+int view_main(seqan3::argument_parser & view_parser)
+{
+    view_options options{};
+
+    view_parser.add_positional_option(options.jst_file,
+                                       "The jst file.",
+                                       seqan3::input_file_validator{{"jst"}});
+    view_parser.add_option(options.haplotype_index,
+                            '\0',
+                            "haplotype-index",
+                            "The index of the haplotype to print to the command line in fasta format.",
+                            seqan3::option_spec::standard,
+                            seqan3::arithmetic_range_validator<size_t>{0, std::numeric_limits<size_t>::max()});
+
+    try
+    {
+        view_parser.parse();
+    }
+    catch (seqan3::argument_parser_error const & ex)
+    {
+        std::cerr << "[ERROR] While parsing command line options: " << ex.what() << "\n";
+        return -1;
+    }
+
+    // ----------------------------------------------------------------------------
+    // Run the viewer.
+    // ----------------------------------------------------------------------------
+
+    int error_code = 0;
+    try
+    {
+        auto jst = jstmap::load_jst(options.jst_file);
+        view_as_format(jst, options.haplotype_index);
+    }
+    catch (std::exception const & ex)
+    {
+        std::cerr << "[ERROR] While viewing the jst content: " << ex.what() << "\n";
+        error_code = -1;
+    }
+
+    return error_code;
+}
+
+} // namespace jstmap

--- a/jstmap-view/jstmap/view/view_main.hpp
+++ b/jstmap-view/jstmap/view/view_main.hpp
@@ -1,0 +1,27 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/rrahn/just_map/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides the main entry point of the just_map viewer.
+ * \author Rene Rahn <rene.rahn AT fu-berlin.de>
+ */
+
+#pragma once
+
+namespace seqan3
+{
+
+class argument_parser;
+
+} // namespace seqan3
+
+namespace jstmap
+{
+
+int view_main(seqan3::argument_parser &);
+
+} // namespace jstmap

--- a/jstmap/CMakeLists.txt
+++ b/jstmap/CMakeLists.txt
@@ -2,5 +2,12 @@
 
 set (target_name "${CMAKE_PROJECT_NAME}")
 add_executable ("${CMAKE_PROJECT_NAME}" jstmap/main.cpp)
-target_include_directories ("${CMAKE_PROJECT_NAME}" PUBLIC seqan3::seqan3 jstmap::index jstmap::search jstmap::simulate)
-target_link_libraries ("${CMAKE_PROJECT_NAME}" PUBLIC seqan3::seqan3 jstmap::index jstmap::search jstmap::simulate)
+target_include_directories ("${CMAKE_PROJECT_NAME}" PUBLIC seqan3::seqan3
+                                                           jstmap::index
+                                                           jstmap::search
+                                                           jstmap::simulate)
+target_link_libraries ("${CMAKE_PROJECT_NAME}" PUBLIC seqan3::seqan3
+                                                      jstmap::index
+                                                      jstmap::search
+                                                      jstmap::simulate
+                                                      jstmap::view)

--- a/jstmap/jstmap/main.cpp
+++ b/jstmap/jstmap/main.cpp
@@ -14,6 +14,7 @@
 #include <jstmap/index/index_main.hpp> // Pulls in the index sub-command.
 #include <jstmap/search/search_main.hpp> // Pulls in the search sub-command.
 #include <jstmap/simulate/simulate_main.hpp> // Pulls in the search sub-command.
+#include <jstmap/view/view_main.hpp> // Pulls in the view sub-command.
 
 namespace jstmap
 {
@@ -24,6 +25,7 @@ struct tool_names
     inline static const std::string index{"index"};
     inline static const std::string search{"search"};
     inline static const std::string simulate{"simulate"};
+    inline static const std::string view{"view"};
 
     static std::string subparser_name_for(std::string_view subcommand)
     {
@@ -37,7 +39,10 @@ int main(int const argc, char * const argv[])
 {
 
     seqan3::argument_parser jstmap_parser{jstmap::tool_names::base, argc, argv, seqan3::update_notifications::off,
-                                          {jstmap::tool_names::index, jstmap::tool_names::search, jstmap::tool_names::simulate}};
+                                          {jstmap::tool_names::index,
+                                           jstmap::tool_names::search,
+                                           jstmap::tool_names::simulate,
+                                           jstmap::tool_names::view}};
 
     jstmap_parser.info.description.push_back("The famous population mapper based on journaled string trees.");
 
@@ -55,6 +60,8 @@ int main(int const argc, char * const argv[])
             return jstmap::search_main(selected_parser);
         else if (selected_parser.info.app_name == jstmap::tool_names::subparser_name_for(jstmap::tool_names::simulate))
             return jstmap::simulate_main(selected_parser);
+        else if (selected_parser.info.app_name == jstmap::tool_names::subparser_name_for(jstmap::tool_names::view))
+            return jstmap::view_main(selected_parser);
         else
             std::cerr << "Unknown subparser: " << selected_parser.info.app_name << '\n';
     }

--- a/test/api/jstmap/view/CMakeLists.txt
+++ b/test/api/jstmap/view/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required (VERSION 3.14)
+
+macro (add_jstmap_view_test test_filename)
+    add_api_test(${test_filename} "jstmap::view")
+endmacro ()
+
+add_jstmap_view_test (view_format_fasta_test.cpp)
+target_use_datasources (view_format_fasta_test FILES sim_refx5.jst)

--- a/test/api/jstmap/view/view_format_fasta_test.cpp
+++ b/test/api/jstmap/view/view_format_fasta_test.cpp
@@ -1,0 +1,40 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+
+#include <jstmap/view/load_jst.hpp>
+#include <jstmap/view/view_format_fasta.hpp>
+
+TEST(jstmap_view_test, view_format_fasta)
+{
+    std::filesystem::path jst_file{DATADIR"sim_refx5.jst"};
+    jstmap::jst_t jst = jstmap::load_jst(jst_file);
+
+    testing::internal::CaptureStdout();
+
+    jstmap::view_as_format(jst, 0);
+
+    std::string captured_output = testing::internal::GetCapturedStdout();
+
+    std::string expected_output{R"fasta(> ID_0
+TATGCACCAGAGTATGGAAGCATAAGCTCTGCATGCAAAGGTACATCAGATCCTGCGGTTGGGTGCCAACCCAAGTGTGT
+TCACGGGCGC
+)fasta"};
+
+    EXPECT_EQ(captured_output, expected_output);
+}
+
+TEST(jstmap_view_test, view_format_fasta_unknown_haplpotype_index)
+{
+    std::filesystem::path jst_file{DATADIR"sim_refx5.jst"};
+    jstmap::jst_t jst = jstmap::load_jst(jst_file);
+
+    EXPECT_THROW(jstmap::view_as_format(jst, 6), std::out_of_range);
+}


### PR DESCRIPTION
This sub-command allows to visualise any particular haplotype in fasta format.

This allows to generate the haplotype for any sequence contained in the jst. 
It can be used to simulate some reads for this sequence for further performance analysis of the mapper.