### PR TITLE
Remove seqan3/cereal dependency

### DIFF
--- a/libjst/CMakeLists.txt
+++ b/libjst/CMakeLists.txt
@@ -1,8 +1,25 @@
 cmake_minimum_required (VERSION 3.18)
 
-### Adds an interface library for the jst lib.
+### Finding cereal for serialization.
+find_package (Cereal QUIET)
+
+set (LIBJST_TARGET_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/../libjst)
+set (LIBJST_TARGET_COMPILE_FEATURES cxx_std_20)
+set (LIBJST_TARGET_LINK_LIBRARIES libcontrib::libcontrib)
+
+if (Cereal_FOUND)
+    message (STATUS "Found cereal: ${Cereal_VERSION}")
+    list (APPEND LIBJST_TARGET_INCLUDE_DIRECTORIES cereal::cereal)
+    list (APPEND LIBJST_TARGET_COMPILE_FEATURES cereal::cereal)
+    list (APPEND LIBJST_TARGET_LINK_LIBRARIES cereal::cereal)
+else ()
+    message (STATUS "Cereal not found, serialisation will be disabled.")
+    # Add fetch content for cereal.
+endif ()
+
+### Add an interface library for libjst.
 add_library (libjst_libjst INTERFACE)
-target_include_directories (libjst_libjst INTERFACE ../libjst)
-target_compile_features (libjst_libjst INTERFACE cxx_std_20)
-target_link_libraries (libjst_libjst INTERFACE libcontrib::libcontrib)
+target_include_directories (libjst_libjst INTERFACE ${LIBJST_TARGET_INCLUDE_DIRECTORIES})
+target_compile_features (libjst_libjst INTERFACE ${LIBJST_TARGET_COMPILE_FEATURES})
+target_link_libraries (libjst_libjst INTERFACE ${LIBJST_TARGET_LINK_LIBRARIES})
 add_library (libjst::libjst ALIAS libjst_libjst)

--- a/libjst/libjst/coverage/bit_coverage.hpp
+++ b/libjst/libjst/coverage/bit_coverage.hpp
@@ -15,8 +15,6 @@
 #include <algorithm>
 #include <ranges>
 
-#include <seqan3/core/concept/cereal.hpp>
-
 #include <libjst/coverage/concept.hpp>
 #include <libjst/coverage/range_domain.hpp>
 #include <libjst/utility/bit_vector.hpp>
@@ -162,13 +160,13 @@ namespace libjst
         // Serialisation
         // ----------------------------------------------------------------------------
 
-        template <seqan3::cereal_input_archive archive_t>
+        template <typename archive_t>
         void load(archive_t & iarchive)
         {
             iarchive(_data, _domain);
         }
 
-        template <seqan3::cereal_output_archive archive_t>
+        template <typename archive_t>
         void save(archive_t & oarchive) const
         {
             oarchive(_data, _domain);

--- a/libjst/libjst/coverage/int_coverage.hpp
+++ b/libjst/libjst/coverage/int_coverage.hpp
@@ -15,8 +15,6 @@
 #include <algorithm>
 #include <ranges>
 
-#include <seqan3/core/concept/cereal.hpp>
-
 #include <libjst/coverage/range_domain.hpp>
 #include <libjst/utility/sorted_vector.hpp>
 
@@ -147,13 +145,13 @@ namespace libjst
         // Serialisation
         // ----------------------------------------------------------------------------
 
-        template <seqan3::cereal_input_archive archive_t>
+        template <typename archive_t>
         void load(archive_t & iarchive)
         {
             iarchive(_data, _domain);
         }
 
-        template <seqan3::cereal_output_archive archive_t>
+        template <typename archive_t>
         void save(archive_t & oarchive) const
         {
             oarchive(_data, _domain);

--- a/libjst/libjst/coverage/range_domain.hpp
+++ b/libjst/libjst/coverage/range_domain.hpp
@@ -15,8 +15,6 @@
 #include <algorithm>
 #include <stdint.h>
 
-#include <seqan3/core/concept/cereal.hpp>
-
 namespace libjst
 {
 
@@ -55,13 +53,13 @@ namespace libjst
         // Serialisation
         // ----------------------------------------------------------------------------
 
-        template <seqan3::cereal_input_archive archive_t>
+        template <typename archive_t>
         void load(archive_t & iarchive)
         {
             iarchive(_min, _max);
         }
 
-        template <seqan3::cereal_output_archive archive_t>
+        template <typename archive_t>
         void save(archive_t & oarchive) const
         {
             oarchive(_min, _max);

--- a/libjst/libjst/rcms/compressed_multisequence.hpp
+++ b/libjst/libjst/rcms/compressed_multisequence.hpp
@@ -17,7 +17,6 @@
 #include <unordered_map>
 
 #include <seqan3/utility/detail/multi_invocable.hpp>
-#include <seqan3/core/concept/cereal.hpp>
 
 #include <libcontrib/type_traits.hpp>
 #include <libcontrib/std/tag_invoke.hpp>
@@ -187,13 +186,13 @@ namespace libjst
         // Serialisation
         // ----------------------------------------------------------------------------
 
-        template <seqan3::cereal_input_archive archive_t>
+        template <typename archive_t>
         void load(archive_t & iarchive)
         {
             iarchive(_source, _breakend_map, /*_indel_map,*/ _coverage_domain);
         }
 
-        template <seqan3::cereal_output_archive archive_t>
+        template <typename archive_t>
         void save(archive_t & oarchive) const
         {
             oarchive(_source, _breakend_map, /*_indel_map,*/ _coverage_domain);

--- a/libjst/libjst/rcms/contiguous_multimap.hpp
+++ b/libjst/libjst/rcms/contiguous_multimap.hpp
@@ -16,8 +16,6 @@
 #include <bit>
 #include <concepts>
 
-#include <seqan3/core/concept/cereal.hpp>
-
 #include <libjst/utility/sorted_vector.hpp>
 #include <libjst/utility/stable_random_access_iterator.hpp>
 
@@ -134,13 +132,13 @@ namespace libjst
         // Serialisation
         // ----------------------------------------------------------------------------
 
-        template <seqan3::cereal_input_archive archive_t>
+        template <typename archive_t>
         void load(archive_t & iarchive)
         {
             iarchive(_breakends, _data);
         }
 
-        template <seqan3::cereal_output_archive archive_t>
+        template <typename archive_t>
         void save(archive_t & oarchive) const
         {
             oarchive(_breakends, _data);

--- a/libjst/libjst/rcms/delta_sequence_variant.hpp
+++ b/libjst/libjst/rcms/delta_sequence_variant.hpp
@@ -16,7 +16,6 @@
 #include <span>
 #include <variant>
 
-#include <seqan3/core/concept/cereal.hpp>
 #include <seqan3/utility/detail/multi_invocable.hpp>
 
 #include <libjst/rcms/packed_breakend_key.hpp>

--- a/libjst/libjst/rcms/generic_delta.hpp
+++ b/libjst/libjst/rcms/generic_delta.hpp
@@ -14,8 +14,6 @@
 
 #include <concepts>
 
-#include <seqan3/core/concept/cereal.hpp>
-
 #include <libcontrib/type_traits.hpp>
 #include <libcontrib/std/tag_invoke.hpp>
 
@@ -42,13 +40,13 @@ namespace libjst
         // Serialisation
         // ----------------------------------------------------------------------------
 
-        template <seqan3::cereal_input_archive archive_t>
+        template <typename archive_t>
         void load(archive_t & iarchive)
         {
             iarchive(_breakpoint, _alt_sequence, _coverage);
         }
 
-        template <seqan3::cereal_output_archive archive_t>
+        template <typename archive_t>
         void save(archive_t & oarchive) const
         {
             oarchive(_breakpoint, _alt_sequence, _coverage);

--- a/libjst/libjst/rcms/indel_variant.hpp
+++ b/libjst/libjst/rcms/indel_variant.hpp
@@ -16,8 +16,6 @@
 
 #include <cereal/types/variant.hpp>
 
-#include <seqan3/core/concept/cereal.hpp>
-
 namespace libjst
 {
 
@@ -45,13 +43,13 @@ namespace libjst
         // Serialisation
         // ----------------------------------------------------------------------------
 
-        template <seqan3::cereal_input_archive archive_t>
+        template <typename archive_t>
         void load(archive_t & iarchive)
         {
             iarchive(value());
         }
 
-        template <seqan3::cereal_output_archive archive_t>
+        template <typename archive_t>
         void save(archive_t & oarchive) const
         {
             oarchive(value());
@@ -84,13 +82,13 @@ namespace libjst
         // Serialisation
         // ----------------------------------------------------------------------------
 
-        template <seqan3::cereal_input_archive archive_t>
+        template <typename archive_t>
         void load(archive_t & iarchive)
         {
             iarchive(value());
         }
 
-        template <seqan3::cereal_output_archive archive_t>
+        template <typename archive_t>
         void save(archive_t & oarchive) const
         {
             oarchive(value());
@@ -134,13 +132,13 @@ namespace libjst
         // Serialisation
         // ----------------------------------------------------------------------------
 
-        template <seqan3::cereal_input_archive archive_t>
+        template <typename archive_t>
         void load(archive_t & iarchive)
         {
             iarchive(_indel);
         }
 
-        template <seqan3::cereal_output_archive archive_t>
+        template <typename archive_t>
         void save(archive_t & oarchive) const
         {
             oarchive(_indel);

--- a/libjst/libjst/rcms/packed_breakend_key.hpp
+++ b/libjst/libjst/rcms/packed_breakend_key.hpp
@@ -15,8 +15,6 @@
 #include <concepts>
 #include <type_traits>
 
-#include <seqan3/core/concept/cereal.hpp>
-
 namespace libjst
 {
     enum class indel_breakend_kind {
@@ -90,7 +88,7 @@ namespace libjst
         // Serialisation
         // ----------------------------------------------------------------------------
 
-        template <seqan3::cereal_input_archive archive_t>
+        template <typename archive_t>
         void load(archive_t & iarchive)
         {
             position_t packed_key{};
@@ -99,7 +97,7 @@ namespace libjst
             _position = packed_key;
         }
 
-        template <seqan3::cereal_output_archive archive_t>
+        template <typename archive_t>
         void save(archive_t & oarchive) const
         {
             position_t packed_key = _code << ((sizeof(position_t) * 8) - 3ull);

--- a/libjst/libjst/rcms/rcs_store.hpp
+++ b/libjst/libjst/rcms/rcs_store.hpp
@@ -15,7 +15,6 @@
 #include <algorithm>
 
 #include <seqan3/alphabet/range/sequence.hpp>
-#include <seqan3/core/concept/cereal.hpp>
 
 #include <libjst/variant/concept.hpp>
 
@@ -116,13 +115,13 @@ namespace libjst
         // Serialisation
         // ----------------------------------------------------------------------------
 
-        template <seqan3::cereal_input_archive archive_t>
+        template <typename archive_t>
         void load(archive_t & iarchive)
         {
             iarchive(_variant_map);
         }
 
-        template <seqan3::cereal_output_archive archive_t>
+        template <typename archive_t>
         void save(archive_t & oarchive) const
         {
             oarchive(_variant_map);

--- a/libjst/libjst/rcms/rcs_store_reversed.hpp
+++ b/libjst/libjst/rcms/rcs_store_reversed.hpp
@@ -15,7 +15,6 @@
 #include <algorithm>
 
 #include <seqan3/alphabet/range/sequence.hpp>
-#include <seqan3/core/concept/cereal.hpp>
 
 #include <libjst/rcms/compressed_multisequence_reversed.hpp>
 

--- a/libjst/libjst/sequence_tree/node_descriptor.hpp
+++ b/libjst/libjst/sequence_tree/node_descriptor.hpp
@@ -16,7 +16,6 @@
 #include <string_view>
 
 #include <seqan3/core/add_enum_bitwise_operators.hpp>
-#include <seqan3/core/concept/cereal.hpp>
 
 namespace libjst
 {
@@ -142,13 +141,13 @@ namespace libjst {
             return _state;
         }
 
-        template <seqan3::cereal_output_archive archive_t>
+        template <typename archive_t>
         void save(archive_t & oarchive) const
         {
             oarchive(_state, _on_alternate_path);
         }
 
-        template <seqan3::cereal_input_archive archive_t>
+        template <typename archive_t>
         void load(archive_t & iarchive)
         {
             iarchive(_state, _on_alternate_path);

--- a/libjst/libjst/sequence_tree/path_descriptor.hpp
+++ b/libjst/libjst/sequence_tree/path_descriptor.hpp
@@ -22,8 +22,6 @@
 
 #include <cereal/types/array.hpp>
 
-#include <seqan3/core/concept/cereal.hpp>
-
 namespace libjst
 {
 
@@ -90,13 +88,13 @@ namespace libjst
             return bits_per_word * word_count;
         }
 
-        template <seqan3::cereal_output_archive archive_t>
+        template <typename archive_t>
         void save(archive_t const & oarchive) const
         {
             oarchive(_data);
         }
 
-        template <seqan3::cereal_input_archive archive_t>
+        template <typename archive_t>
         void load(archive_t &iarchive) noexcept
         {
             iarchive(_data);
@@ -274,13 +272,13 @@ namespace libjst
             return iterator{std::addressof(get_word()), 0};
         }
 
-        template <seqan3::cereal_output_archive archive_t>
+        template <typename archive_t>
         void save(archive_t const & oarchive) const
         {
             oarchive(get_word());
         }
 
-        template <seqan3::cereal_input_archive archive_t>
+        template <typename archive_t>
         void load(archive_t &iarchive) noexcept
         {
             iarchive(get_word());

--- a/libjst/libjst/sequence_tree/seek_position.hpp
+++ b/libjst/libjst/sequence_tree/seek_position.hpp
@@ -17,8 +17,6 @@
 
 #include <cereal/types/base_class.hpp>
 
-#include <seqan3/core/concept/cereal.hpp>
-
 #include <libjst/sequence_tree/breakend_site.hpp>
 #include <libjst/sequence_tree/path_descriptor.hpp>
 
@@ -79,14 +77,14 @@ namespace libjst
             }
         }
 
-        template <seqan3::cereal_output_archive archive_t>
+        template <typename archive_t>
         void save(archive_t & oarchive) const
         {
             oarchive(_active_descriptor, _variant_index);
             visit([&] (auto const & descriptor) { oarchive(descriptor); });
         }
 
-        template <seqan3::cereal_input_archive archive_t>
+        template <typename archive_t>
         void load(archive_t & iarchive)
         {
             iarchive(_active_descriptor, _variant_index);

--- a/libjst/libjst/serialisation/concept.hpp
+++ b/libjst/libjst/serialisation/concept.hpp
@@ -1,0 +1,189 @@
+// Adds basic serialisation concepts and default functions using tag_invoke based CPOs
+
+#pragma once
+
+#include <libcontrib/std/tag_invoke.hpp>
+
+#if __has_include(<cereal/cereal.hpp>)
+#include <cereal/cereal.hpp>
+
+namespace libjst::detail {
+
+    inline constexpr bool has_cereal = true;
+
+    template <typename archive_t>
+    concept cereal_input_archive = std::derived_from<archive_t, cereal::detail::InputArchiveBase>;
+
+    template <typename archive_t>
+    concept cereal_output_archive = std::derived_from<archive_t, cereal::detail::OutputArchiveBase>;
+
+}
+
+#else
+
+namespace libjst::detail {
+
+    inline constexpr bool has_cereal = false;
+
+    template <typename archive_t>
+    concept cereal_input_archive = true;
+
+    template <typename archive_t>
+    concept cereal_output_archive = true;
+}
+
+#endif
+
+/**
+ * @defgroup serialisation Serialisation
+ *
+ * General serialisation support.
+ */
+
+namespace libjst {
+
+    namespace _load {
+
+        inline constexpr struct _cpo {
+            /**
+             * @brief Calling this CPO will load an object from a given input archive.
+             *
+             * @tparam object_t The object type.
+             * @tparam iarchive_t The input archive type.
+             *                    Must be an <a href="https://uscilab.github.io/cereal/assets/doxygen/classcereal_1_1InputArchive.html">cereal::InputArchive</a>.
+             * @param object The object to load.
+             * @param iarchive The input archive to load from.
+             *
+             * To use this CPO, the object type must offer one of the following three function signatures:
+             *   - A member function with the signature `void load(iarchive_t&)`;
+             *   - A free function with the signature `void load(object_t&, iarchive_t&)`;
+             *   - Or a std::tag_invocable overload with the signature `friend void tag_invoke(std::tag_t<libjst::load>, object_t&, iarchive_t&)`.
+             *
+             * @ingroup serialisation
+             */
+            template <typename object_t, detail::cereal_input_archive iarchive_t>
+                requires (detail::has_cereal) && (std::tag_invocable<_cpo, object_t&, iarchive_t&>)
+            constexpr auto operator()(object_t& object, iarchive_t& iarchive) const
+                noexcept(std::is_nothrow_tag_invocable_v<_cpo, object_t&, iarchive_t &>)
+                -> std::tag_invoke_result_t<_cpo, object_t&, iarchive_t&> {
+                return std::tag_invoke(_cpo{}, object, iarchive);
+            }
+
+            /**
+             * @brief Default overload if cereal is not available.
+             *
+             * This overload will always throw a std::runtime_error.
+             */
+            template <typename object_t, typename iarchive_t>
+                requires (!detail::has_cereal)
+            constexpr void operator()(object_t&, iarchive_t&) const {
+                throw std::runtime_error("libjst::load: cereal is not available");
+            }
+
+        private:
+            /**
+             * @brief This overload is only enabled if the member load function is available.
+             */
+            template <typename object_t, typename iarchive_t>
+                requires (requires(object_t& object, iarchive_t& iarchive) {
+                            { object.load(iarchive) } -> std::same_as<void>;
+                         })
+            friend void tag_invoke(_cpo, object_t& object, iarchive_t& iarchive)
+                noexcept(noexcept(object.load(iarchive))) {
+                object.load(iarchive);
+            }
+
+            /**
+             * @brief This overload is only enabled if the free load function is available
+             *        and the member load function is not available
+             */
+            template <typename object_t, typename iarchive_t>
+                requires (!requires(object_t& object, iarchive_t& iarchive) {
+                            { object.load(iarchive) } -> std::same_as<void>;
+                         }) &&
+                         (requires(object_t& object, iarchive_t& iarchive) {
+                            { load(object, iarchive) } -> std::same_as<void>;
+                         })
+            friend void tag_invoke(_cpo, object_t& object, iarchive_t& iarchive)
+                noexcept(noexcept(load(object, iarchive))) {
+                load(object, iarchive);
+            }
+        } load;
+    } // namespace _load
+
+    using _load::load;
+
+    // Add CPO implementation to save objects using cereal output archives
+    namespace _save
+    {
+        inline constexpr struct _cpo {
+            /**
+             * @brief Calling this CPO will save an object to a given output archive.
+             *
+             * @tparam object_t The object type.
+             * @tparam oarchive_t The output archive type.
+             *                    Must be an <a href="https://uscilab.github.io/cereal/assets/doxygen/classcereal_1_1OutputArchive.html">cereal::OutputArchive</a>.
+             *
+             * @param object The object to save.
+             * @param oarchive The output archive to save to.
+             *
+             * To use this CPO, the object type must offer one of the following three function signatures:
+             *  - A member function with the signature `void save(oarchive_t&) const`;
+             *  - A free function with the signature `void save(object_t const &, oarchive_t&)`;
+             *  - Or a std::tag_invocable overload with the signature `friend void tag_invoke(std::tag_t<libjst::save>, object_t const &, oarchive_t&)`.
+             *
+             * @ingroup serialisation
+             */
+            template <typename object_t, detail::cereal_output_archive oarchive_t>
+                requires (detail::has_cereal) && (std::tag_invocable<_cpo, object_t&, oarchive_t&>)
+            constexpr auto operator()(object_t const & object, oarchive_t& oarchive) const
+                noexcept(std::is_nothrow_tag_invocable_v<_cpo, object_t const &, oarchive_t &>)
+                -> std::tag_invoke_result_t<_cpo, object_t const &, oarchive_t&> {
+                return std::tag_invoke(_cpo{}, object, oarchive);
+            }
+
+            /**
+             * @brief This overload is only enabled if cereal is not available.
+             *
+             * This overload will always throw a std::runtime_error.
+             */
+            template <typename object_t, typename oarchive_t>
+                requires (!detail::has_cereal)
+            void operator()(object_t&, oarchive_t&) const {
+                throw std::runtime_error("libjst::save: cereal is not available");
+            }
+
+        private:
+
+            /**
+             * @brief Default overload using the save member function.
+             */
+            template <typename object_t, typename oarchive_t>
+                requires (requires(object_t const & object, oarchive_t& oarchive) {
+                            { object.save(oarchive) } -> std::same_as<void>;
+                         })
+            friend void tag_invoke(_cpo, object_t const & object, oarchive_t& oarchive)
+                noexcept(noexcept(object.save(oarchive))) {
+                object.save(oarchive);
+            }
+
+            /**
+             * @brief Default overload using a free save function.
+             */
+            template <typename object_t, typename oarchive_t>
+                requires (!requires(object_t const & object, oarchive_t& oarchive) {
+                            { object.save(oarchive) } -> std::same_as<void>;
+                         }) &&
+                         (requires(object_t const & object, oarchive_t& oarchive) {
+                            { save(object, oarchive) } -> std::same_as<void>;
+                         })
+            friend void tag_invoke(_cpo, object_t const & object, oarchive_t& oarchive)
+                noexcept(noexcept(save(object, oarchive))) {
+                save(object, oarchive);
+            }
+
+        } save;
+    }
+
+    using _save::save;
+}

--- a/libjst/libjst/utility/bit_vector_base.hpp
+++ b/libjst/libjst/utility/bit_vector_base.hpp
@@ -21,7 +21,6 @@
 
 #include <cereal/types/base_class.hpp>
 
-#include <seqan3/core/concept/cereal.hpp>
 #include <seqan3/utility/detail/bits_of.hpp>
 
 namespace libjst
@@ -518,11 +517,11 @@ public:
      */
     /*!\brief Saves this bit vector to the given output archive.
      *
-     * \tparam output_archive_t The type of the output_archive; must model seqan3::cereal_output_archive.
+     * \tparam output_archive_t The type of the output_archive; must model typename.
      *
      * \param[in, out] archive The archive to serialise this object to.
      */
-    template <seqan3::cereal_output_archive output_archive_t>
+    template <typename output_archive_t>
     void save(output_archive_t & archive) const
     {
         archive(cereal::base_class<base_t>(this), _size);
@@ -530,11 +529,11 @@ public:
 
     /*!\brief Loads this this bit vector from the given input archive.
      *
-     * \tparam input_archive_t The type of the input_archive; must model seqan3::cereal_input_archive.
+     * \tparam input_archive_t The type of the input_archive; must model typename.
      *
      * \param[in, out] archive The archive to serialise this object from.
      */
-    template <seqan3::cereal_input_archive input_archive_t>
+    template <typename input_archive_t>
     void load(input_archive_t & archive)
     {
         archive(cereal::base_class<base_t>(this), _size);

--- a/libjst/libjst/utility/bit_vector_simd.hpp
+++ b/libjst/libjst/utility/bit_vector_simd.hpp
@@ -177,7 +177,7 @@ public:
     //!\endcond
 
     //!\copydoc libjst::bit_vector_base::load
-    template <seqan3::cereal_input_archive input_archive_t>
+    template <typename input_archive_t>
     void load(input_archive_t & archive)
     {
         base_t::load(archive);

--- a/libjst/libjst/utility/sorted_vector.hpp
+++ b/libjst/libjst/utility/sorted_vector.hpp
@@ -20,8 +20,6 @@
 
 #include <cereal/types/vector.hpp>
 
-#include <seqan3/core/concept/cereal.hpp>
-
 #include <libjst/utility/stable_random_access_iterator.hpp>
 
 namespace libjst
@@ -308,13 +306,13 @@ public:
     // Serialisation
     // ----------------------------------------------------------------------------
 
-    template <seqan3::cereal_input_archive archive_t>
+    template <typename archive_t>
     void load(archive_t & iarchive)
     {
         iarchive(_elements);
     }
 
-    template <seqan3::cereal_output_archive archive_t>
+    template <typename archive_t>
     void save(archive_t & oarchive) const
     {
         oarchive(_elements);

--- a/libjst/libjst/variant/breakpoint.hpp
+++ b/libjst/libjst/variant/breakpoint.hpp
@@ -16,8 +16,6 @@
 #include <concepts>
 #include <string_view>
 
-#include <seqan3/core/concept/cereal.hpp>
-
 #include <libcontrib/type_traits.hpp>
 
 #include <libjst/variant/concept.hpp>
@@ -95,7 +93,7 @@ namespace libjst
             return static_cast<int_t>(value());
         }
 
-        template <seqan3::cereal_output_archive output_archive_t>
+        template <typename output_archive_t>
         uint32_t save_minimal(output_archive_t const &) const
         {
             uint32_t tmp = _end_marker;
@@ -103,7 +101,7 @@ namespace libjst
             return tmp;
         }
 
-        template <seqan3::cereal_input_archive input_archive_t>
+        template <typename input_archive_t>
         void load_minimal(input_archive_t const &, uint32_t const &tmp)
         {
             _value = tmp;

--- a/test/api/libjst/serialisation/CMakeLists.txt
+++ b/test/api/libjst/serialisation/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_libjst2_test (load_cpo_test.cpp)
+add_libjst2_test (save_cpo_test.cpp)

--- a/test/api/libjst/serialisation/load_cpo_test.cpp
+++ b/test/api/libjst/serialisation/load_cpo_test.cpp
@@ -1,0 +1,169 @@
+//// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <type_traits>
+
+#include <libjst/serialisation/concept.hpp>
+
+// Check if cereal is available
+#if __has_include(<cereal/cereal.hpp>)
+#include <cereal/archives/binary.hpp>
+#endif
+
+namespace libjst::test
+{
+
+    struct test_object_free_load
+    {
+        int a{};
+        int b{};
+        int c{};
+    };
+
+    template <typename archive_t>
+    void load(test_object_free_load &object, archive_t &archive)
+    {
+        archive(object.a, object.b, object.c);
+    }
+} // namespace libjst::test
+
+TEST(load_cpo, using_free_function)
+{
+#if __has_include(<cereal/cereal.hpp>)
+    {
+        std::stringstream stream{};
+        {
+            cereal::BinaryOutputArchive oarchive{stream};
+            oarchive(1, 2, 3);
+        }
+
+        libjst::test::test_object_free_load object{};
+        // Test before loading
+        EXPECT_EQ(object.a, 0);
+        EXPECT_EQ(object.b, 0);
+        EXPECT_EQ(object.c, 0);
+        {
+            cereal::BinaryInputArchive iarchive{stream};
+            libjst::load(object, iarchive);
+        }
+        // Test after loading
+        EXPECT_EQ(object.a, 1);
+        EXPECT_EQ(object.b, 2);
+        EXPECT_EQ(object.c, 3);
+    }
+#else
+    {
+        libjst::test::test_object_free_load test_object{};
+        std::stringstream archive_mock{"1, 2, 3"};
+        EXPECT_THROW(libjst::load(test_object, archive_mock), std::runtime_error);
+    }
+#endif
+}
+
+namespace libjst::test
+{
+
+    struct test_object_member_load
+    {
+        int a{};
+        int b{};
+        int c{};
+
+        template <typename archive_t>
+        void load(archive_t &archive)
+        {
+            archive(a, b, c);
+        }
+    };
+}
+
+TEST(load_cpo, using_member_function)
+{
+#if __has_include(<cereal/cereal.hpp>)
+    {
+        std::stringstream stream{};
+        {
+            cereal::BinaryOutputArchive oarchive{stream};
+            oarchive(1, 2, 3);
+        }
+
+        libjst::test::test_object_member_load object{};
+        // Test before loading
+        EXPECT_EQ(object.a, 0);
+        EXPECT_EQ(object.b, 0);
+        EXPECT_EQ(object.c, 0);
+        {
+            cereal::BinaryInputArchive iarchive{stream};
+            libjst::load(object, iarchive);
+        }
+        // Test after loading
+        EXPECT_EQ(object.a, 1);
+        EXPECT_EQ(object.b, 2);
+        EXPECT_EQ(object.c, 3);
+    }
+#else
+    {
+        libjst::test::test_object_member_load test_object{};
+        std::stringstream archive_mock{"1, 2, 3"};
+        EXPECT_THROW(libjst::load(test_object, archive_mock), std::runtime_error);
+    }
+#endif
+}
+
+namespace libjst::test
+{
+
+    struct test_object_tag_invoke
+    {
+        int a{};
+        int b{};
+        int c{};
+
+    private:
+
+        template <typename archive_t>
+        friend void tag_invoke(std::tag_t<libjst::load>, test_object_tag_invoke &object, archive_t &archive)
+        {
+            archive(object.a, object.b, object.c);
+        }
+    };
+} // namespace libjst::test
+
+TEST(load_cpo, using_tag_invoke_friend)
+{
+#if __has_include(<cereal/cereal.hpp>)
+    {
+        std::stringstream stream{};
+        {
+            cereal::BinaryOutputArchive oarchive{stream};
+            oarchive(1, 2, 3);
+        }
+
+        libjst::test::test_object_tag_invoke object{};
+        // Test before loading
+        EXPECT_EQ(object.a, 0);
+        EXPECT_EQ(object.b, 0);
+        EXPECT_EQ(object.c, 0);
+        {
+            cereal::BinaryInputArchive iarchive{stream};
+            libjst::load(object, iarchive);
+        }
+        // Test after loading
+        EXPECT_EQ(object.a, 1);
+        EXPECT_EQ(object.b, 2);
+        EXPECT_EQ(object.c, 3);
+    }
+#else
+    {
+        libjst::test::test_object_tag_invoke test_object{};
+        std::stringstream archive_mock{"1, 2, 3"};
+        EXPECT_THROW(libjst::load(test_object, archive_mock), std::runtime_error);
+    }
+#endif
+}

--- a/test/api/libjst/serialisation/save_cpo_test.cpp
+++ b/test/api/libjst/serialisation/save_cpo_test.cpp
@@ -1,0 +1,162 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+// add include for std::as_const
+#include <utility>
+
+#include <libjst/serialisation/concept.hpp>
+
+#if __has_include(<cereal/cereal.hpp>)
+#include <cereal/archives/binary.hpp>
+#endif
+
+namespace libjst::test
+{
+
+    struct test_object_free_save
+    {
+        int a{};
+        int b{};
+        int c{};
+    };
+
+    template <typename archive_t>
+    void save(test_object_free_save const &object, archive_t &archive)
+    {
+        archive(object.a, object.b, object.c);
+    }
+} // namespace libjst::test
+
+TEST(save_cpo, using_free_function)
+{
+#if __has_include(<cereal/cereal.hpp>)
+    {
+
+        std::stringstream stream{};
+        {
+            cereal::BinaryOutputArchive oarchive{stream};
+            libjst::test::test_object_free_save object{.a = 1, .b = 2, .c = 3};
+            libjst::save(std::as_const(object), oarchive);
+        }
+
+        libjst::test::test_object_free_save expected_object{};
+        {
+            cereal::BinaryInputArchive iarchive{stream};
+            iarchive(expected_object.a, expected_object.b, expected_object.c);
+        }
+
+        EXPECT_EQ(expected_object.a, 1);
+        EXPECT_EQ(expected_object.b, 2);
+        EXPECT_EQ(expected_object.c, 3);
+    }
+#else
+    {
+        // No cereal available -> save should throw
+        std::stringstream archive_mock{};
+        libjst::test::test_object_free_save object{.a = 1, .b = 2, .c = 3};
+        EXPECT_THROW(libjst::save(std::as_const(object), archive_mock), std::runtime_error);
+    }
+#endif
+}
+
+namespace libjst::test
+{
+    struct test_object_member_save
+    {
+        int a{};
+        int b{};
+        int c{};
+
+        template <typename archive_t>
+        void save(archive_t &archive) const
+        {
+            archive(a, b, c);
+        }
+    };
+} // namespace libjst::test
+
+TEST(save_cpo, using_member_function)
+{
+#if __has_include(<cereal/cereal.hpp>)
+    {
+        std::stringstream stream{};
+        {
+            cereal::BinaryOutputArchive oarchive{stream};
+            libjst::test::test_object_member_save object{.a = 1, .b = 2, .c = 3};
+            std::as_const(object).save(oarchive);
+        }
+
+        libjst::test::test_object_member_save expected_object{};
+        {
+            cereal::BinaryInputArchive iarchive{stream};
+            iarchive(expected_object.a, expected_object.b, expected_object.c);
+        }
+
+        EXPECT_EQ(expected_object.a, 1);
+        EXPECT_EQ(expected_object.b, 2);
+        EXPECT_EQ(expected_object.c, 3);
+    }
+#else
+    {
+        // No cereal available -> save should throw
+        std::stringstream archive_mock{};
+        libjst::test::test_object_member_save object{.a = 1, .b = 2, .c = 3};
+        EXPECT_THROW(std::as_const(object).save(archive_mock), std::runtime_error);
+    }
+#endif
+}
+
+namespace libjst::test
+{
+    struct test_object_save_tag_invoke
+    {
+        int a{};
+        int b{};
+        int c{};
+
+    private:
+        template <typename archive_t>
+        friend void tag_invoke(std::tag_t<libjst::save>, test_object_save_tag_invoke const &object, archive_t &archive)
+        {
+            archive(object.a, object.b, object.c);
+        }
+    };
+
+} // namespace libjst::test
+
+TEST(save_cpo, using_tag_invoke)
+{
+#if __has_include(<cereal/cereal.hpp>)
+    {
+        std::stringstream stream{};
+        {
+            cereal::BinaryOutputArchive oarchive{stream};
+            libjst::test::test_object_save_tag_invoke object{.a = 1, .b = 2, .c = 3};
+            libjst::save(std::as_const(object), oarchive);
+        }
+
+        libjst::test::test_object_save_tag_invoke expected_object{};
+        {
+            cereal::BinaryInputArchive iarchive{stream};
+            iarchive(expected_object.a, expected_object.b, expected_object.c);
+        }
+
+        EXPECT_EQ(expected_object.a, 1);
+        EXPECT_EQ(expected_object.b, 2);
+        EXPECT_EQ(expected_object.c, 3);
+    }
+#else
+    {
+        // No cereal available -> save should throw
+        std::stringstream archive_mock{};
+        libjst::test::test_object_save_tag_invoke object{.a = 1, .b = 2, .c = 3};
+        EXPECT_THROW(libjst::save(std::as_const(object), archive_mock), std::runtime_error);
+    }
+#endif
+}


### PR DESCRIPTION
Uses own setup to handle optional cereal dependency.
Cereal is optional and only searched on the system paths.
Users need to install cereal on their own.
Since it is optional, we resolve to a runtime exception in the 
case users call load or save via the corresponding CPO implementations.

Thus, for serializable objects in libjst it is recommended to use `libjst::load(obj, archive)` and `libjst::save(obj, archive)`.